### PR TITLE
Feature/fix workflow response

### DIFF
--- a/03_Infrastructure/ti8m.BeachBreak.QueryApi/Dto/QuestionResponseDataDto.cs
+++ b/03_Infrastructure/ti8m.BeachBreak.QueryApi/Dto/QuestionResponseDataDto.cs
@@ -7,9 +7,9 @@ namespace ti8m.BeachBreak.QueryApi.Dto;
 /// Base class for different types of question response data.
 /// This maintains type safety while being independent of domain value objects.
 /// </summary>
-[JsonDerivedType(typeof(TextResponseDataDto), typeDiscriminator: "text")]
-[JsonDerivedType(typeof(AssessmentResponseDataDto), typeDiscriminator: "assessment")]
-[JsonDerivedType(typeof(GoalResponseDataDto), typeDiscriminator: "goal")]
+[JsonDerivedType(typeof(AssessmentResponseDataDto), typeDiscriminator: 0)]
+[JsonDerivedType(typeof(TextResponseDataDto), typeDiscriminator: 1)]
+[JsonDerivedType(typeof(GoalResponseDataDto), typeDiscriminator: 2)]
 public abstract class QuestionResponseDataDto
 {
 }

--- a/05_Frontend/ti8m.BeachBreak.Client/Converters/QuestionResponseDataDtoJsonConverter.cs
+++ b/05_Frontend/ti8m.BeachBreak.Client/Converters/QuestionResponseDataDtoJsonConverter.cs
@@ -14,14 +14,11 @@ public class QuestionResponseDataDtoJsonConverter : JsonConverter<QuestionRespon
     {
         if (reader.TokenType != JsonTokenType.StartObject)
         {
-            Console.WriteLine($"DEBUG CONVERTER: Expected StartObject, got {reader.TokenType}");
             return null;
         }
 
         using var doc = JsonDocument.ParseValue(ref reader);
         var root = doc.RootElement;
-
-        Console.WriteLine($"DEBUG CONVERTER: Raw JSON: {root.GetRawText()}");
 
         // Try to get the $type discriminator
         string? typeDiscriminator = null;
@@ -32,17 +29,11 @@ public class QuestionResponseDataDtoJsonConverter : JsonConverter<QuestionRespon
             if (typeElement.ValueKind == JsonValueKind.String)
             {
                 typeDiscriminator = typeElement.GetString();
-                Console.WriteLine($"DEBUG CONVERTER: Found string discriminator: '{typeDiscriminator}'");
             }
             else if (typeElement.ValueKind == JsonValueKind.Number)
             {
                 numericDiscriminator = typeElement.GetInt32();
-                Console.WriteLine($"DEBUG CONVERTER: Found numeric discriminator: {numericDiscriminator}");
             }
-        }
-        else
-        {
-            Console.WriteLine("DEBUG CONVERTER: No $type discriminator found");
         }
 
         // Create the appropriate type based on discriminator
@@ -57,7 +48,6 @@ public class QuestionResponseDataDtoJsonConverter : JsonConverter<QuestionRespon
                 2 => JsonSerializer.Deserialize<GoalResponseDataDto>(root.GetRawText(), options),
                 _ => null
             };
-            Console.WriteLine($"DEBUG CONVERTER: Created {result?.GetType().Name} from numeric discriminator {numericDiscriminator}");
         }
         else if (!string.IsNullOrEmpty(typeDiscriminator))
         {
@@ -68,7 +58,6 @@ public class QuestionResponseDataDtoJsonConverter : JsonConverter<QuestionRespon
                 "goal" => JsonSerializer.Deserialize<GoalResponseDataDto>(root.GetRawText(), options),
                 _ => null
             };
-            Console.WriteLine($"DEBUG CONVERTER: Created {result?.GetType().Name} from string discriminator '{typeDiscriminator}'");
         }
         else
         {
@@ -76,27 +65,15 @@ public class QuestionResponseDataDtoJsonConverter : JsonConverter<QuestionRespon
             if (root.TryGetProperty("Evaluations", out _))
             {
                 result = JsonSerializer.Deserialize<AssessmentResponseDataDto>(root.GetRawText(), options);
-                Console.WriteLine("DEBUG CONVERTER: Inferred AssessmentResponseDataDto from Evaluations property");
             }
             else if (root.TryGetProperty("TextSections", out _))
             {
                 result = JsonSerializer.Deserialize<TextResponseDataDto>(root.GetRawText(), options);
-                Console.WriteLine("DEBUG CONVERTER: Inferred TextResponseDataDto from TextSections property");
             }
             else if (root.TryGetProperty("Goals", out _))
             {
                 result = JsonSerializer.Deserialize<GoalResponseDataDto>(root.GetRawText(), options);
-                Console.WriteLine("DEBUG CONVERTER: Inferred GoalResponseDataDto from Goals property");
             }
-        }
-
-        if (result == null)
-        {
-            Console.WriteLine("DEBUG CONVERTER: Failed to create any response data type!");
-        }
-        else
-        {
-            Console.WriteLine($"DEBUG CONVERTER: Successfully created {result.GetType().Name}");
         }
 
         return result;

--- a/05_Frontend/ti8m.BeachBreak.Client/Converters/QuestionResponseDataDtoJsonConverter.cs
+++ b/05_Frontend/ti8m.BeachBreak.Client/Converters/QuestionResponseDataDtoJsonConverter.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ti8m.BeachBreak.Client.Models.DTOs;
+
+namespace ti8m.BeachBreak.Client.Converters;
+
+/// <summary>
+/// Custom JSON converter for QuestionResponseDataDto that handles both string and numeric discriminators
+/// and provides detailed logging for debugging deserialization issues.
+/// </summary>
+public class QuestionResponseDataDtoJsonConverter : JsonConverter<QuestionResponseDataDto>
+{
+    public override QuestionResponseDataDto? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            Console.WriteLine($"DEBUG CONVERTER: Expected StartObject, got {reader.TokenType}");
+            return null;
+        }
+
+        using var doc = JsonDocument.ParseValue(ref reader);
+        var root = doc.RootElement;
+
+        Console.WriteLine($"DEBUG CONVERTER: Raw JSON: {root.GetRawText()}");
+
+        // Try to get the $type discriminator
+        string? typeDiscriminator = null;
+        int? numericDiscriminator = null;
+
+        if (root.TryGetProperty("$type", out var typeElement))
+        {
+            if (typeElement.ValueKind == JsonValueKind.String)
+            {
+                typeDiscriminator = typeElement.GetString();
+                Console.WriteLine($"DEBUG CONVERTER: Found string discriminator: '{typeDiscriminator}'");
+            }
+            else if (typeElement.ValueKind == JsonValueKind.Number)
+            {
+                numericDiscriminator = typeElement.GetInt32();
+                Console.WriteLine($"DEBUG CONVERTER: Found numeric discriminator: {numericDiscriminator}");
+            }
+        }
+        else
+        {
+            Console.WriteLine("DEBUG CONVERTER: No $type discriminator found");
+        }
+
+        // Create the appropriate type based on discriminator
+        QuestionResponseDataDto? result = null;
+
+        if (numericDiscriminator.HasValue)
+        {
+            result = numericDiscriminator.Value switch
+            {
+                0 => JsonSerializer.Deserialize<AssessmentResponseDataDto>(root.GetRawText(), options),
+                1 => JsonSerializer.Deserialize<TextResponseDataDto>(root.GetRawText(), options),
+                2 => JsonSerializer.Deserialize<GoalResponseDataDto>(root.GetRawText(), options),
+                _ => null
+            };
+            Console.WriteLine($"DEBUG CONVERTER: Created {result?.GetType().Name} from numeric discriminator {numericDiscriminator}");
+        }
+        else if (!string.IsNullOrEmpty(typeDiscriminator))
+        {
+            result = typeDiscriminator switch
+            {
+                "assessment" => JsonSerializer.Deserialize<AssessmentResponseDataDto>(root.GetRawText(), options),
+                "text" => JsonSerializer.Deserialize<TextResponseDataDto>(root.GetRawText(), options),
+                "goal" => JsonSerializer.Deserialize<GoalResponseDataDto>(root.GetRawText(), options),
+                _ => null
+            };
+            Console.WriteLine($"DEBUG CONVERTER: Created {result?.GetType().Name} from string discriminator '{typeDiscriminator}'");
+        }
+        else
+        {
+            // Fallback: try to infer from properties
+            if (root.TryGetProperty("Evaluations", out _))
+            {
+                result = JsonSerializer.Deserialize<AssessmentResponseDataDto>(root.GetRawText(), options);
+                Console.WriteLine("DEBUG CONVERTER: Inferred AssessmentResponseDataDto from Evaluations property");
+            }
+            else if (root.TryGetProperty("TextSections", out _))
+            {
+                result = JsonSerializer.Deserialize<TextResponseDataDto>(root.GetRawText(), options);
+                Console.WriteLine("DEBUG CONVERTER: Inferred TextResponseDataDto from TextSections property");
+            }
+            else if (root.TryGetProperty("Goals", out _))
+            {
+                result = JsonSerializer.Deserialize<GoalResponseDataDto>(root.GetRawText(), options);
+                Console.WriteLine("DEBUG CONVERTER: Inferred GoalResponseDataDto from Goals property");
+            }
+        }
+
+        if (result == null)
+        {
+            Console.WriteLine("DEBUG CONVERTER: Failed to create any response data type!");
+        }
+        else
+        {
+            Console.WriteLine($"DEBUG CONVERTER: Successfully created {result.GetType().Name}");
+        }
+
+        return result;
+    }
+
+    public override void Write(Utf8JsonWriter writer, QuestionResponseDataDto value, JsonSerializerOptions options)
+    {
+        // Let the default serialization handle writing
+        JsonSerializer.Serialize(writer, (object)value, value.GetType(), options);
+    }
+}

--- a/05_Frontend/ti8m.BeachBreak.Client/Models/Dto/Api/ApiSectionResponseDto.cs
+++ b/05_Frontend/ti8m.BeachBreak.Client/Models/Dto/Api/ApiSectionResponseDto.cs
@@ -9,7 +9,7 @@ public class ApiSectionResponseDto
     public Guid SectionId { get; set; }
 
     /// <summary>
-    /// Role-based response structure: ResponseRole (Employee/Manager) -> QuestionResponse
+    /// Role-based response structure: ResponseRole (Employee/Manager) -> SectionId -> QuestionResponse
     /// </summary>
-    public Dictionary<ResponseRole, QuestionResponseDto> RoleResponses { get; set; } = new();
+    public Dictionary<ResponseRole, Dictionary<string, QuestionResponseDto>> RoleResponses { get; set; } = new();
 }

--- a/05_Frontend/ti8m.BeachBreak.Client/Models/Dto/Queries/QuestionResponseDataDto.cs
+++ b/05_Frontend/ti8m.BeachBreak.Client/Models/Dto/Queries/QuestionResponseDataDto.cs
@@ -6,10 +6,8 @@ namespace ti8m.BeachBreak.Client.Models.DTOs;
 /// <summary>
 /// Base class for different types of question response data.
 /// This maintains type safety while matching the API structure.
+/// Uses custom QuestionResponseDataDtoJsonConverter for polymorphic deserialization.
 /// </summary>
-[JsonDerivedType(typeof(TextResponseDataDto), typeDiscriminator: "text")]
-[JsonDerivedType(typeof(AssessmentResponseDataDto), typeDiscriminator: "assessment")]
-[JsonDerivedType(typeof(GoalResponseDataDto), typeDiscriminator: "goal")]
 public abstract class QuestionResponseDataDto
 {
 }

--- a/05_Frontend/ti8m.BeachBreak.Client/Pages/DynamicQuestionnaire.razor
+++ b/05_Frontend/ti8m.BeachBreak.Client/Pages/DynamicQuestionnaire.razor
@@ -632,9 +632,11 @@ else
         {
             QuestionnaireResponse? existingResponse = null;
 
-            // After review meeting, everyone loads ALL role responses for full transparency
+            // After submission and review phases, everyone loads ALL role responses for full transparency
             var isPostReviewState = assignment != null &&
-                (assignment.WorkflowState is WorkflowState.ManagerReviewConfirmed or
+                (assignment.WorkflowState is WorkflowState.BothSubmitted or
+                                             WorkflowState.InReview or
+                                             WorkflowState.ManagerReviewConfirmed or
                                              WorkflowState.EmployeeReviewConfirmed or
                                              WorkflowState.Finalized);
 

--- a/05_Frontend/ti8m.BeachBreak.Client/Services/BaseApiService.cs
+++ b/05_Frontend/ti8m.BeachBreak.Client/Services/BaseApiService.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using ti8m.BeachBreak.Client.Converters;
 
 namespace ti8m.BeachBreak.Client.Services;
 
@@ -14,7 +15,8 @@ public abstract class BaseApiService
     protected static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = null, // PascalCase
-        PropertyNameCaseInsensitive = false // Strict enforcement
+        PropertyNameCaseInsensitive = false, // Strict enforcement
+        Converters = { new QuestionResponseDataDtoJsonConverter() }
     };
 
     protected BaseApiService(IHttpClientFactory factory)


### PR DESCRIPTION
Fix questionnaire response data deserialization and display
- Update JSON discriminators to use numeric values (0,1,2) instead of strings for consistency across APIs
- Create custom QuestionResponseDataDtoJsonConverter for robust polymorphic JSON deserialization
- Fix API response structure mapping to handle nested role->sectionId->response format
- Add BothSubmitted workflow state to post-review states for proper response loading
- Update ApiSectionResponseDto to correctly map nested response structure
- Add manual JSON deserialization with custom options to ensure proper type handling
- Remove JsonDerivedType attributes to avoid conflicts with custom converter

Resolves issue where questionnaire responses displayed "Not rated" instead of actual assessment ratings despite valid API data. All rating values (1-4) now display correctly as stars and labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4 <noreply@anthropic.com>